### PR TITLE
fix: match error for self closing macro components

### DIFF
--- a/lib/surface/code/formatter.ex
+++ b/lib/surface/code/formatter.ex
@@ -393,8 +393,7 @@ defmodule Surface.Code.Formatter do
 
     rendered_children =
       if render_contents_verbatim?(tag) do
-        [contents] = children
-        contents
+        Enum.join(children, "")
       else
         next_opts = Keyword.update(opts, :indent, 0, &(&1 + 1))
 

--- a/test/surface/code_test.exs
+++ b/test/surface/code_test.exs
@@ -99,6 +99,17 @@ defmodule Surface.CodeTest do
     )
   end
 
+  test "Self closing Macro Components are preserved" do
+    test_formatter(
+      """
+      <#MacroComponent />
+      """,
+      """
+      <#MacroComponent />
+      """
+    )
+  end
+
   test "lack of whitespace is preserved" do
     test_formatter(
       """


### PR DESCRIPTION
Thanks for putting this together!

I found a small issue when running this against my own project with self closing macro components, but everything else worked perfectly