### PR TITLE
Handle non-text contents in <pre>/<code>/<#Macro> tags

### DIFF
--- a/lib/surface/code/formatter.ex
+++ b/lib/surface/code/formatter.ex
@@ -393,8 +393,15 @@ defmodule Surface.Code.Formatter do
 
     rendered_children =
       if render_contents_verbatim?(tag) do
-        [contents] = children
-        contents
+        Enum.map(children, fn
+          html when is_binary(html) ->
+            # Render out string portions of <pre>/<code>/<#MacroComponent> children
+            # verbatim instead of trimming them.
+            html
+
+          child ->
+            render_node(child, indent: 0)
+        end)
       else
         next_opts = Keyword.update(opts, :indent, 0, &(&1 + 1))
 

--- a/test/surface/code_test.exs
+++ b/test/surface/code_test.exs
@@ -369,7 +369,76 @@ defmodule Surface.CodeTest do
     )
   end
 
-  test "Fix bug in UCBI dev" do
+  test "<pre>, <code>, and <#MacroComponent> tags can contain interpolations or components, but the string portions are untouched" do
+    # Note that the output looks pretty messy, but it's because
+    # we're retaining 100% of the exact characters between the
+    # <pre> and </pre> tags, etc.
+    #
+    # Also, note that the _opening_ tags are consistently at the same
+    # indentation level because those tags are not inside a context
+    # in which we render children verbatim. (In other words, there's
+    # no risk of changing browser behavior.)
+    test_formatter(
+      """
+      <pre>
+      {{   @data   }}
+            <Component />
+      </pre>
+          <code>
+        {{ @data }}
+        <Component />
+          </code>
+
+
+            <#MacroComponent> Foo {{@bar}} baz </#MacroComponent>
+      """,
+      """
+      <pre>
+      {{ @data }}
+            <Component />
+      </pre>
+      <code>
+        {{ @data }}
+        <Component />
+          </code>
+
+      <#MacroComponent> Foo {{@bar}} baz </#MacroComponent>
+      """
+    )
+  end
+
+  test "HTML elements rendered in <pre>/<code>/<#MacroComponent> tags are left in their original state" do
+    test_formatter(
+      """
+      <pre>
+          <div>    <p>  Hello world  </p>  </div>
+        </pre>
+
+        <code>
+            <div>    <p>  Hello world  </p>  </div>
+          </code>
+
+          <#Macro>
+              <div>    <p>  Hello world  </p>  </div>
+            </#Macro>
+      """,
+      """
+      <pre>
+          <div>    <p>  Hello world  </p>  </div>
+        </pre>
+
+      <code>
+            <div>    <p>  Hello world  </p>  </div>
+          </code>
+
+      <#Macro>
+              <div>    <p>  Hello world  </p>  </div>
+            </#Macro>
+      """
+    )
+  end
+
+  test "Attributes are lines up properly when split onto newlines with a multi-line attribute" do
     test_formatter(
       """
       <Parent>


### PR DESCRIPTION
Running `mix surface.format` on the [Surface site](https://github.com/surface-ui/surface_site) repo revealed this bug/crash:

```
mix surface.format failed for file: lib/surface_site_web/live/contexts/example01.ex
** (MatchError) no match of right hand side value: ["\n      ", {:interpolation, " @data ", %{line: 14}}, "\n      "]
    (surface_formatter 0.1.0) lib/surface/code/formatter.ex:387: Surface.Code.Formatter.render_node/2
```

The formatter assumed these "render children verbatim" tags would only have a single string child, such as:

```html
<pre>
  This is string content that doesn't contain any surface components, HTML tags, or interpolations.
</pre>
```

So code like this would break:

```html
<code>
  <p>Hello</p>
</code>
```

```html
<code>
  {{ @data }}
</code>
```

```html
<code>
  <SomeComponent />
</code>
```