### PR TITLE
Fix the formatting of html comments

### DIFF
--- a/lib/surface/formatter/phases/tag_whitespace.ex
+++ b/lib/surface/formatter/phases/tag_whitespace.ex
@@ -77,6 +77,7 @@ defmodule Surface.Formatter.Phases.TagWhitespace do
   end
 
   def tag_whitespace({:interpolation, _, _} = interpolation), do: [interpolation]
+  def tag_whitespace({:comment, _} = comment), do: [comment]
 
   # Tag a string that only has whitespace, returning [:space] or a list of `:newline`
   @spec tag_whitespace_string(String.t() | nil) :: list(:space | :newline)

--- a/lib/surface/formatter/render.ex
+++ b/lib/surface/formatter/render.ex
@@ -47,6 +47,10 @@ defmodule Surface.Formatter.Render do
     " "
   end
 
+  def node({:comment, comment}, _opts) do
+    comment
+  end
+
   def node(:indent_one_less, opts) do
     # Dedent once; this is before a closing tag, so it should be dedented from children
     node(:indent, indent: opts[:indent] - 1)

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -660,6 +660,7 @@ defmodule Surface.FormatterTest do
       <div>
         <Component />
 
+        <!-- Comment -->
         <AfterComment />
       </div>
       """
@@ -798,6 +799,7 @@ defmodule Surface.FormatterTest do
         causing_this_line_to_wrap
         because_it_is_too_long="yes, this line is long enough to wrap"
       >
+        <!-- An HTML comment -->
         {{ # An Elixir comment }}
 
         <div :if={{ @show_div }} class="container">


### PR DESCRIPTION
Fixes the broken tests on master by adding support for HTML comments in the formatter