### PR TITLE
Formatter fails on string literals in {#match, "block"}

### DIFF
--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1095,6 +1095,11 @@ defmodule Surface.FormatterTest do
               Value is empty
             </div>
 
+          {#match "string"}
+
+
+            <div>String Value</div>
+
           {#match _}
 
             Value is something else


### PR DESCRIPTION
Here's a failing test case. I started to attempt to fix it, but it looks like there's some refactoring needed in `Render.render_node/2`. I tried to make an attempt at fixing it but its probably better for @paulstatezny to look into this