### PR TITLE
Fix crash when reading from stdin

### DIFF
--- a/lib/mix/tasks/surface/format.ex
+++ b/lib/mix/tasks/surface/format.ex
@@ -64,10 +64,12 @@ defmodule Mix.Tasks.Surface.Format do
   #
 
   defp format_file_contents!(:stdin, input, opts) do
-    try do
-      Formatter.format_string!(input, opts)
-    rescue
-      _error -> format_ex_string!(input, opts)
+    case Code.string_to_quoted(input) do
+      {:ok, _} ->
+        format_ex_string!(input, opts)
+
+      {:error, _} ->
+        Formatter.format_string!(input, opts)
     end
   end
 

--- a/lib/mix/tasks/surface/format.ex
+++ b/lib/mix/tasks/surface/format.ex
@@ -333,7 +333,7 @@ defmodule Mix.Tasks.Surface.Format do
   end
 
   defp read_file(:stdin) do
-    {IO.stream() |> Enum.to_list() |> IO.iodata_to_binary(), file: "stdin"}
+    {IO.stream(:stdio, :line) |> Enum.to_list() |> IO.iodata_to_binary(), file: "stdin"}
   end
 
   defp read_file(file) do

--- a/lib/mix/tasks/surface/format.ex
+++ b/lib/mix/tasks/surface/format.ex
@@ -64,6 +64,7 @@ defmodule Mix.Tasks.Surface.Format do
   #
 
   defp format_file_contents!(:stdin, input, opts) do
+    # determine whether the input is Elixir or Surface code by checking if `Code.string_to_quoted` can parse it
     case Code.string_to_quoted(input) do
       {:ok, _} ->
         format_ex_string!(input, opts)

--- a/lib/mix/tasks/surface/format.ex
+++ b/lib/mix/tasks/surface/format.ex
@@ -63,6 +63,14 @@ defmodule Mix.Tasks.Surface.Format do
   # Functions unique to surface.format (Everything else is taken from Mix.Tasks.Format)
   #
 
+  defp format_file_contents!(:stdin, input, opts) do
+    try do
+      Formatter.format_string!(input, opts)
+    rescue
+      _error -> format_ex_string!(input, opts)
+    end
+  end
+
   defp format_file_contents!(file, input, opts) do
     case Path.extname(file) do
       ".sface" ->
@@ -319,6 +327,10 @@ defmodule Mix.Tasks.Surface.Format do
     end
 
     opts
+  end
+
+  defp read_file(:stdin) do
+    {IO.stream() |> Enum.to_list() |> IO.iodata_to_binary(), file: "stdin"}
   end
 
   defp read_file(file) do

--- a/test/mix/tasks/surface/format_test.exs
+++ b/test/mix/tasks/surface/format_test.exs
@@ -1,0 +1,85 @@
+defmodule Surface.Mix.Tasks.FormatTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  describe "reads from stdin and prints to stdout with formatter" do
+    test "handles an Elixir file" do
+      file = """
+      defmodule Card do
+        use Surface.Component
+
+        def render(assigns) do
+          ~F\"\"\"
+          <div>
+          <ul>
+          <li>
+          <a>
+          Hello
+          </a>
+          </li>
+          </ul>
+          </div>
+          \"\"\"
+        end
+      end
+      """
+
+      formatted = """
+      defmodule Card do
+        use Surface.Component
+
+        def render(assigns) do
+          ~F\"\"\"
+          <div>
+            <ul>
+              <li>
+                <a>
+                  Hello
+                </a>
+              </li>
+            </ul>
+          </div>
+          \"\"\"
+        end
+      end
+      """
+
+      assert formatted ==
+               capture_io(file, fn ->
+                 Mix.Tasks.Surface.Format.run(["-"])
+               end)
+    end
+
+    test "handles a Surface file" do
+      file = """
+      <div>
+      <ul>
+      <li>
+      <a>
+      Hello
+      </a>
+      </li>
+      </ul>
+      </div>
+      """
+
+      formatted = """
+      <div>
+        <ul>
+          <li>
+            <a>
+              Hello
+            </a>
+          </li>
+        </ul>
+      </div>
+      """
+
+      assert formatted ==
+               capture_io(file, fn ->
+                 Mix.Tasks.Surface.Format.run(["-"])
+               end)
+    end
+  end
+end


### PR DESCRIPTION
Greetings! I'm working on an integration with [null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim) and discovered that reading from stdin appears to be broken. To reproduce, try the following with any Elixir or Surface file:

```
$ cat example.ex | mix surface.format -
```
On master, this raises the following error:

```
mix surface.format failed for stdin
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1

    The following arguments were given to IO.chardata_to_string/1:

        # 1
        :stdin

    Attempted function clauses (showing 2 out of 2):

        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)

    (elixir 1.12.2) lib/io.ex:615: IO.chardata_to_string/1
    (elixir 1.12.2) lib/file.ex:341: File.read/1
    (elixir 1.12.2) lib/file.ex:350: File.read!/1
    lib/mix/tasks/surface/format.ex:325: Mix.Tasks.Surface.Format.read_file/1
    lib/mix/tasks/surface/format.ex:153: Mix.Tasks.Surface.Format.format_file/2
    (elixir 1.12.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.12.2) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib 3.15.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

This PR fixes the issue by porting over the stdin handling from [mix format](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/format.ex#L408) and, since we do not have the file extension available, determines if the input is Elixir code via `Code.string_to_quoted/1` and runs the appropriate format function.