### PR TITLE
Handle {=foo} alongside {=@foo} for tagged expression attributes using variables

### DIFF
--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -331,8 +331,8 @@ defmodule Surface.Formatter.Phases.Render do
   defp render_attribute({name, value, _meta}, _opts) when is_integer(value),
     do: "#{name}={#{Code.format_string!("#{value}")}}"
 
-  defp render_attribute({name, {:attribute_expr, _, %{tagged_expr?: true}}, _}, _) do
-    "{=@#{name}}"
+  defp render_attribute({_name, {:attribute_expr, expression, %{tagged_expr?: true}}, _}, _opts) do
+    "{=#{expression}}"
   end
 
   defp render_attribute({name, {:attribute_expr, expression, _expr_meta}, _meta}, opts)

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -902,6 +902,15 @@ defmodule Surface.FormatterTest do
         """
       )
 
+      assert_formatter_outputs(
+        """
+        <Foo {= bar} />
+        """,
+        """
+        <Foo {=bar} />
+        """
+      )
+
       # demonstrate that the formatter is unopinionated about short or longhand
       # in this scenario
       assert_formatter_outputs(


### PR DESCRIPTION
Fixes #45