### PR TITLE
Fix crash when ran as Formatter Plugin without line_length or surface_line_length

### DIFF
--- a/lib/surface/formatter/plugin.ex
+++ b/lib/surface/formatter/plugin.ex
@@ -56,7 +56,8 @@ defmodule Surface.Formatter.Plugin do
   end
 
   def format(contents, opts) do
-    opts = Keyword.put(opts, :line_length, opts[:surface_line_length] || opts[:line_length])
+    line_length = opts[:surface_line_length] || opts[:line_length]
+    opts = if line_length, do: Keyword.put(opts, :line_length, line_length), else: opts
     Surface.Formatter.format_string!(contents, opts)
   end
 end

--- a/test/surface/formatter/plugin_test.exs
+++ b/test/surface/formatter/plugin_test.exs
@@ -65,6 +65,7 @@ defmodule Surface.Formatter.PluginTest do
   test ":surface_line_length overrides :line_length" do
     assert_formatter_output(
       "surface_line_length.ex",
+      [line_length: 200, surface_line_length: 50],
       """
       defmodule Foo do
         def render(assigns) do
@@ -88,6 +89,20 @@ defmodule Surface.Formatter.PluginTest do
           \"\"\"
         end
       end
+      """
+    )
+  end
+
+  test "omitting :line_length and :surface_line_length defaults to default line_length" do
+    # reproducing a bug that occurred when both were omitted, with an Elixir expression
+    assert_formatter_output(
+      "config.sface",
+      [],
+      """
+        {@foo}
+      """,
+      """
+      {@foo}
       """
     )
   end


### PR DESCRIPTION
Fixes #52.