### PR TITLE
fix format for `:hook` directive

### DIFF
--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -333,6 +333,10 @@ defmodule Surface.Formatter.Phases.Render do
     {:do_not_indent_newlines, rendered}
   end
 
+  # Only for :hook directive return itself since isn't an boolean directive
+  # and could be defined without value and assuming the `"default"`.
+  defp render_attribute({":hook" = name, true, _meta}, _opts), do: "#{name}"
+
   # For `true` boolean attributes, simply including the name of the attribute
   # without `=true` is shorthand for `=true`.
   defp render_attribute({":" <> _ = name, true, _meta}, _opts),

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1000,6 +1000,12 @@ defmodule Surface.FormatterTest do
       )
     end
 
+    test ":hook directive without any attribute" do
+      assert_formatter_doesnt_change("""
+      <div :hook />
+      """)
+    end
+
     test "true boolean attribute in directive" do
       assert_formatter_doesnt_change("""
       <div :if={true} />


### PR DESCRIPTION
it should not format when has an `:hook` directive without any attribute.

This fix it is related with this PR here: https://github.com/surface-ui/surface/pull/636