### PR TITLE
Fix warning about negative steps on Elixir 1.16

### DIFF
--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -130,7 +130,7 @@ defmodule Surface.Formatter.Phases.Render do
 
             string ->
               string
-              |> String.slice(1..-2)
+              |> String.slice(1..-2//1)
               |> String.trim()
           end
 


### PR DESCRIPTION
When I run the formatter, I get this warning...

```
warning: negative steps are not supported in String.slice/2, pass 1..-2//1 instead
  (elixir 1.16.0) lib/string.ex:2368: String.slice/2
  (surface_formatter 0.7.5) lib/surface/formatter/phases/render.ex:133: Surface.Formatter.Phases.Render.render_node/2
  (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (surface_formatter 0.7.5) lib/surface/formatter/phases/render.ex:189: Surface.Formatter.Phases.Render.render_node/2
  (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
```

This PR should fix it.